### PR TITLE
[WIP] PWA関連のUX向上

### DIFF
--- a/components/utils/AppBar.vue
+++ b/components/utils/AppBar.vue
@@ -7,6 +7,7 @@
     </span>
 
     <div class="profile">
+      <InstallButton />
       <div class="avatar" @click="pushRoute('/setting')">
         <img
           :src="userProfile.photoURL"
@@ -25,16 +26,16 @@ import {
   ref,
   useRoute,
 } from '@nuxtjs/composition-api'
+import InstallButton from './InstallButton.vue'
 import auth from '~/composable/firebase/auth'
 import useUserProfile, { userProfileKey, userProfileType } from '~/composition/userProfile'
 import usePageTransition, { pageTransitionKey, pageTransitionType } from '~/composition/pageTransition'
 
 export default defineComponent({
+  components: { InstallButton },
   setup () {
     // const
-    const {
-      push,
-    } = inject(pageTransitionKey, usePageTransition()) as pageTransitionType
+    const { push } = inject(pageTransitionKey, usePageTransition()) as pageTransitionType
     const { trySignIn, trySignOut } = auth()
     const { userProfile } = inject(userProfileKey, useUserProfile()) as userProfileType
     const route = useRoute()
@@ -55,12 +56,10 @@ export default defineComponent({
     const nowPath = computed(() => {
       return route.value.path
     })
-
     // methods
     const pushRoute = (path: string) => {
       push(nowPath.value, path)
     }
-
     return {
       nowPage,
       items,
@@ -94,6 +93,9 @@ export default defineComponent({
       .avatar {
         width: 36px;
         height: 36px;
+
+        margin-left: 16px;
+
         border-radius: 50%;
         background-color: $gray-lighten-1;
         cursor: pointer;

--- a/components/utils/AppBar.vue
+++ b/components/utils/AppBar.vue
@@ -7,23 +7,6 @@
     </span>
 
     <div class="profile">
-      <!-- <span style="margin-right: 8px">{{ userProfile.name }}</span> -->
-      <!-- <Button
-        v-if="userProfile.uid"
-        color="transparent"
-        text-color="white"
-        icon="mdiLogoutVariant"
-        style="margin-right: 4px"
-        @click="trySignOut()"
-      />
-      <Button
-        v-else
-        color="transparent"
-        text-color="white"
-        icon="mdiLoginVariant"
-        style="margin-right: 4px"
-        @click="trySignIn()"
-      /> -->
       <div class="avatar" @click="pushRoute('/setting')">
         <img
           :src="userProfile.photoURL"

--- a/components/utils/InstallButton.vue
+++ b/components/utils/InstallButton.vue
@@ -1,0 +1,29 @@
+<template>
+  <Button
+    icon="mdiOpenInApp"
+    text-color="white"
+    @click="openInstallationPrompt"
+  >
+    インストール画面を開く
+  </Button>
+</template>
+
+<script lang="ts">
+import { defineComponent } from '@nuxtjs/composition-api'
+
+export default defineComponent({
+  setup () {
+    const openInstallationPrompt = () => {
+
+    }
+
+    return {
+      openInstallationPrompt,
+    }
+  },
+})
+</script>
+
+<style lang="scss" scoped>
+
+</style>

--- a/components/utils/InstallButton.vue
+++ b/components/utils/InstallButton.vue
@@ -1,5 +1,6 @@
 <template>
   <Button
+    v-if="!isInstalled"
     icon="mdiOpenInApp"
     text-color="white"
     @click="openInstallationPrompt"
@@ -9,15 +10,49 @@
 </template>
 
 <script lang="ts">
-import { defineComponent } from '@nuxtjs/composition-api'
+import { computed, defineComponent, ref } from '@nuxtjs/composition-api'
 
 export default defineComponent({
   setup () {
-    const openInstallationPrompt = () => {
+    // cconst
+    const deferredPrompt = ref<any | null>(null)
 
+    // computed
+    const isInstalled = computed(() => {
+      if (window.matchMedia('(display-mode: standalone)').matches) {
+        return true
+      } else {
+        return false
+      }
+    })
+
+    // methods
+    const openInstallationPrompt = () => {
+      deferredPrompt.value?.prompt()
+      deferredPrompt.value?.userChoice
+        .then(function (choiceResult: { outcome: string }) {
+          if (choiceResult.outcome === 'dismissed') {
+            console.log('User cancelled home screen install')
+          } else {
+            console.log('User added to home screen')
+          }
+          deferredPrompt.value = null
+        })
     }
 
+    // lifeCycle
+    window.addEventListener('beforeinstallprompt', function (e) {
+      e.preventDefault()
+      console.log(e)
+
+      deferredPrompt.value = e
+
+      return false
+    })
+
     return {
+      isInstalled,
+
       openInstallationPrompt,
     }
   },

--- a/components/utils/InstallButton.vue
+++ b/components/utils/InstallButton.vue
@@ -5,7 +5,7 @@
     text-color="white"
     @click="openInstallationPrompt"
   >
-    インストール画面を開く
+    インストールする
   </Button>
 </template>
 
@@ -30,7 +30,7 @@ export default defineComponent({
     const openInstallationPrompt = () => {
       deferredPrompt.value?.prompt()
       deferredPrompt.value?.userChoice
-        .then(function (choiceResult: { outcome: string }) {
+        .then((choiceResult: { outcome: string }) => {
           if (choiceResult.outcome === 'dismissed') {
             console.log('User cancelled home screen install')
           } else {
@@ -41,13 +41,10 @@ export default defineComponent({
     }
 
     // lifeCycle
-    window.addEventListener('beforeinstallprompt', function (e) {
+    window.addEventListener('beforeinstallprompt', (e) => {
       e.preventDefault()
-      console.log(e)
-
       deferredPrompt.value = e
-
-      return false
+      console.log(deferredPrompt.value)
     })
 
     return {

--- a/components/utils/SnackBar.vue
+++ b/components/utils/SnackBar.vue
@@ -12,11 +12,25 @@
         >
           <div class="icon">
             <Icon
-              :color="data.type === 'success' ? 'blue-lighten-2' : data.type === 'error' ? 'red-lighten-2' : 'yellow-lighten-2'"
-              :icon="data.type === 'success' ? 'mdiCheckCircle' : data.type === 'error' ? 'mdiAlertCircle' : 'mdiInformation'"
+              :color="data.type === 'success' ? 'green-lighten-2' : data.type === 'error' ? 'red-lighten-2' : data.type === 'help' ? 'yellow-lighten-2' : 'blue-lighten-2'"
+              :icon="data.type === 'success' ? 'mdiCheckCircle' : data.type === 'error' ? 'mdiAlertCircle' : data.type === 'help' ? 'mdiInformation' : 'mdiDownload'"
             />
           </div>
-          <div class="contents" v-text="data.content" />
+          <div
+            v-if="data.type === 'pwaInstall'"
+          >
+            <div class="contents">
+              <p>
+                インストールすると、すぐにアプリを起動できます。
+              </p>
+              <InstallButton />
+            </div>
+          </div>
+          <div
+            v-else
+          >
+            <div class="contents" v-text="data.content" />
+          </div>
           <div class="actions">
             <Button
               icon-mode
@@ -32,29 +46,24 @@
 
 <script lang="ts">
 import { defineComponent, inject, onMounted } from '@nuxtjs/composition-api'
+import InstallButton from './InstallButton.vue'
 import returnMdiIcon from '~/composable/utils/returnMdiIcon'
 import useSnackBarNoticeData, { snackBarNoticeDataKey, snackBarNoticeDataType } from '~/composition/snackBarNoticeData'
 
 export default defineComponent({
+  components: { InstallButton },
   setup () {
-    const {
-      snackBarNoticeData,
-      hiddenSnackBarNoticeData,
-    } = inject(snackBarNoticeDataKey, useSnackBarNoticeData()) as snackBarNoticeDataType
-
+    const { snackBarNoticeData, hiddenSnackBarNoticeData } = inject(snackBarNoticeDataKey, useSnackBarNoticeData()) as snackBarNoticeDataType
     const closeSnackBar = () => {
       for (const [key] of Object.entries(snackBarNoticeData)) {
         hiddenSnackBarNoticeData(Number(key))
       }
     }
-
     onMounted(() => {
       setTimeout(closeSnackBar, 15000)
     })
-
     return {
       snackBarNoticeData,
-
       returnMdiIcon,
       hiddenSnackBarNoticeData,
     }
@@ -103,6 +112,11 @@ export default defineComponent({
 
   .contents {
     padding: 8px;
+
+    p {
+      margin-top: 0px;
+      margin-bottom: 16px;
+    }
   }
 
   .actions {
@@ -112,9 +126,9 @@ export default defineComponent({
   }
 
   &[type = 'success'] {
-    background-color: $blue-lighten-2;
+    background-color: $green-lighten-2;
     .icon {
-      background-color: $blue;
+      background-color: $green;
     }
   }
 
@@ -129,6 +143,13 @@ export default defineComponent({
     background-color: $yellow-lighten-2;
     .icon {
       background-color: $yellow;
+    }
+  }
+
+  &[type = 'pwaInstall'] {
+    background-color: $blue-lighten-2;
+    .icon {
+      background-color: $blue;
     }
   }
 }

--- a/composition/snackBarNoticeData.ts
+++ b/composition/snackBarNoticeData.ts
@@ -10,9 +10,13 @@ import {
 
 /**
  * model: 表示フラグ
+ *
  * type: 表示タイプ
+ *
  * content: snackBarに表示するテキスト
+ *
  * timeout: 非表示になるまでのミリ秒時間
+ *
  * conditions: 表示する条件(未実装)
  */
 export interface snackBarNoticeDataInterface {

--- a/composition/snackBarNoticeData.ts
+++ b/composition/snackBarNoticeData.ts
@@ -6,15 +6,21 @@ import {
   InjectionKey,
   shallowReadonly,
   ref,
-  reactive,
 } from '@nuxtjs/composition-api'
 
+/**
+ * model: 表示フラグ
+ * type: 表示タイプ
+ * content: snackBarに表示するテキスト
+ * timeout: 非表示になるまでのミリ秒時間
+ * conditions: 表示する条件(未実装)
+ */
 export interface snackBarNoticeDataInterface {
   model: boolean,
-  type: string,
-  content: string,
+  type: 'success' | 'error' | 'help' | 'pwaInstall',
+  content?: string,
   timeout?: number,
-  conditions?: string,
+  /* conditions?: string, */
   /* buttons?: buttonInterface[] */
 }
 
@@ -22,37 +28,31 @@ export default function useSnackBarNoticeData () {
   /*
     state
   */
-  const state = reactive({
-    snackBarNoticeData: ref<snackBarNoticeDataInterface[]>([
-      {
-        model: true,
-        type: 'help',
-        content: 'アプリがインストール出来ます！',
-      },
-    ]),
-  })
+  const state = {
+    snackBarNoticeData: ref<snackBarNoticeDataInterface[]>([]),
+  }
 
   /*
     mutation
   */
   const addSnackBarNoticeData = (snackBarNoticeData: snackBarNoticeDataInterface) => {
-    state.snackBarNoticeData.push(snackBarNoticeData)
+    state.snackBarNoticeData.value.push(snackBarNoticeData)
   }
 
   const deleteSnackBarNoticeData = (index: number) => {
     if (index === -1) {
       console.log('見つかりませんでした。')
     } else {
-      state.snackBarNoticeData.splice(index, 1)
+      state.snackBarNoticeData.value.splice(index, 1)
     }
   }
 
   const initSnackBarNoticeData = () => {
-    state.snackBarNoticeData = []
+    state.snackBarNoticeData.value = []
   }
 
   const hiddenSnackBarNoticeData = (index: number) => {
-    state.snackBarNoticeData[index].model = false
+    state.snackBarNoticeData.value[index].model = false
   }
 
   /*
@@ -63,6 +63,8 @@ export default function useSnackBarNoticeData () {
     snackBarNoticeData: shallowReadonly(state.snackBarNoticeData),
 
     addSnackBarNoticeData,
+    deleteSnackBarNoticeData,
+    initSnackBarNoticeData,
     hiddenSnackBarNoticeData,
   }
 }

--- a/layouts/default.vue
+++ b/layouts/default.vue
@@ -53,7 +53,7 @@ import usePageTransition, { pageTransitionType, pageTransitionKey } from '~/comp
 import useUserProfile, { userProfileKey, userProfileType } from '~/composition/userProfile'
 import useUserTaskData, { userTaskDataKey, userTaskDataType } from '~/composition/userTaskData'
 import useUserPlanetData, { userPlanetDataKey, userPlanetDataType } from '~/composition/userPlanetData'
-import useSnackBarNoticeData, { snackBarNoticeDataKey } from '~/composition/snackBarNoticeData'
+import useSnackBarNoticeData, { snackBarNoticeDataKey, snackBarNoticeDataType } from '~/composition/snackBarNoticeData'
 
 export default defineComponent({
   components: { NavigationBar, BottomNavigationBar, TaskModal, AppBar, LogInPage, Loading, SnackBar },
@@ -80,6 +80,9 @@ export default defineComponent({
     const {
       getUserPlanetData,
     } = inject(userPlanetDataKey, useUserPlanetData()) as userPlanetDataType
+    const {
+      addSnackBarNoticeData,
+    } = inject(snackBarNoticeDataKey, useSnackBarNoticeData()) as snackBarNoticeDataType
 
     // let, computed
 
@@ -101,6 +104,14 @@ export default defineComponent({
     })
 
     onMounted(() => {
+      if (window.matchMedia('(display-mode: standalone)').matches) {
+        console.log('installed')
+      } else {
+        addSnackBarNoticeData({
+          model: true,
+          type: 'pwaInstall',
+        })
+      }
       window.addEventListener('resize', resizeEvent)
       resizeEvent()
       document.documentElement.style.setProperty('--transition-left', scssVariables.value.left)

--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -33,14 +33,26 @@ export default {
       { hid: 'twitter:image', name: 'twitter:image', content: 'https://firebasestorage.googleapis.com/v0/b/taskmgt-fd097.appspot.com/o/feature.png?alt=media&token=35f7a7b5-b011-4f3d-a461-3e2e42ff2bd5' },
       { name: 'twitter:card', content: 'summary' },
       { hid: 'twitter:site', name: 'twitter:site', content: '@takumaru_2222' },
+      { name: 'apple-mobile-web-app-capable', content: 'yes' },
+      { name: 'apple-mobile-web-app-title', content: 'CHISK' },
     ],
     link: [
       { rel: 'preconnect', href: 'https://fonts.googleapis.com' },
       { rel: 'preconnect', href: 'https://fonts.gstatic.com', crossorigin: true },
       { rel: 'stylesheet', href: 'https://fonts.googleapis.com/css2?family=M+PLUS+1:wght@100;300;400;500;700&display=swap' },
-      { rel: 'icon', type: 'image/x-icon', href: '/icon_512x512.svg' },
+      { rel: 'icon', type: 'image/x-icon', href: '/icon_512x512.png' },
       { rel: 'canonical', href: '/' },
     ],
+    script: [
+      {
+        innerHTML: `
+          if (('standalone' in navigator) && (!navigator.standalone)) {
+            import('https://unpkg.com/pwacompat');
+          }
+        `,
+      },
+    ],
+    __dangerouslyDisableSanitizers: ['script'],
   },
 
   css: [
@@ -84,49 +96,49 @@ export default {
           short_name: 'Taskboard',
           description: 'Open Taskboard',
           url: '/taskboard',
-          icons: [{ src: '/icons/icon_192.svg', sizes: '192x192' }],
+          icons: [{ src: '/icons/icon_192.png', sizes: '192x192' }],
         },
         {
           name: 'Open Setting',
           short_name: 'Setting',
           description: 'Open Setting',
           url: '/setting',
-          icons: [{ src: '/icons/icon_192.svg', sizes: '192x192' }],
+          icons: [{ src: '/icons/icon_192.png', sizes: '192x192' }],
         },
       ],
       icons: [
         {
-          src: '/icons/icon_64.svg',
+          src: '/icons/icon_64.png',
           sizes: '64x64',
           purpose: 'any',
         },
         {
-          src: '/icons/icon_120.svg',
+          src: '/icons/icon_120.png',
           sizes: '120x120',
           purpose: 'any',
         },
         {
-          src: '/icons/icon_144.svg',
+          src: '/icons/icon_144.png',
           sizes: '144x144',
           purpose: 'any',
         },
         {
-          src: '/icons/icon_152.svg',
+          src: '/icons/icon_152.png',
           sizes: '152x152',
           purpose: 'any',
         },
         {
-          src: '/icons/icon_192.svg',
+          src: '/icons/icon_192.png',
           sizes: '192x192',
           purpose: 'any',
         },
         {
-          src: '/icons/icon_384.svg',
+          src: '/icons/icon_384.png',
           sizes: '384x384',
           purpose: 'any',
         },
         {
-          src: '/icons/icon_512.svg',
+          src: '/icons/icon_512.png',
           sizes: '512x512',
           purpose: 'any',
         },


### PR DESCRIPTION
## 実装項目
- [x] 例：項目名(Issue番号でもよい)
- [x] iOS用アプリアイコン・スプラッシュスクリーンの追加
- [ ] アプリインストールボタンの実装
- [x] SnackBarにPWAインストールモードを追加
- [ ] iOSの場合、インストールボタンを押した際にPWAの追加方法を記載したモーダルを表示
- [ ] Androidの場合、インストールプロンプトを表示

## 関連Issue
#6 

## その他留意事項
none